### PR TITLE
Don't reuse connections

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -12,8 +12,7 @@ def database():
 
 
 def logger():
-    conn = database()
-    logger = Logger(os.environ['APPNAME'], 'integrations.py', database)
+    logger = Logger(os.environ['APPNAME'], 'integrations.py', database())
     logger.prepare()
     return logger
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1,26 +1,30 @@
-"""Initializes the logger"""
-from lblogging import Logger, Level
-import os
+"""Contains utility functions to connect with any other services, such as the
+database, while processing a request."""
+from lblogging import Logger
 from pymemcache.client import base as membase
 import psycopg2
 import pika
+import os
 
 
-def _init_logger(database):
-    logger = Logger(os.environ['APPNAME'], 'logging.py', database)
+def database():
+    return psycopg2.connect('')
+
+
+def logger():
+    conn = database()
+    logger = Logger(os.environ['APPNAME'], 'integrations.py', database)
     logger.prepare()
-    logger.print(Level.TRACE, 'Initialized')
-    logger.connection.commit()
     return logger
 
 
-def _init_memcached():
+def memcached():
     memcache_host = os.environ['MEMCACHED_HOST']
     memcache_port = int(os.environ['MEMCACHED_PORT'])
     return membase.Client((memcache_host, memcache_port))
 
 
-def _init_amqp():
+def amqp():
     parameters = pika.ConnectionParameters(
         os.environ['AMQP_HOST'],
         int(os.environ['AMQP_PORT']),
@@ -29,17 +33,7 @@ def _init_amqp():
             os.environ['AMQP_USERNAME'], os.environ['AMQP_PASSWORD']
         )
     )
-    return pika.BlockingConnection(parameters)
-
-
-def _init_amqp_channel(amqp):
+    amqp = pika.BlockingConnection(parameters)
     channel = amqp.channel()
     channel.confirm_delivery()
-    return channel
-
-
-DATABASE = psycopg2.connect('')
-LOGGER = _init_logger(DATABASE)
-MEMCACHED = _init_memcached()
-AMQP = _init_amqp()
-AMQP_CHANNEL = _init_amqp_channel(AMQP)
+    return amqp, channel

--- a/src/main.py
+++ b/src/main.py
@@ -53,5 +53,6 @@ def test_amqp():
                 pub_body, con_body
             )
             logger.connection.commit()
-        channel.cancel()
-        return Response(status_code=status.HTTP_200_OK)
+        else:
+            channel.cancel()
+            return Response(status_code=status.HTTP_200_OK)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Response, status
 from lblogging import Level
-from constants import LOGGER, MEMCACHED as cache, AMQP_CHANNEL as channel
+import integrations
 import json
 import secrets
 
@@ -16,21 +16,28 @@ def root():
 
 @app.get('/test_log')
 def test_log():
+    logger = integrations.logger().with_iden('main.py')
     logger.print(Level.TRACE, 'test_log')
     logger.connection.commit()
+    logger.connection.close()
     return Response(status_code=status.HTTP_200_OK)
 
 
 @app.get('/test_cache')
 def test_cache():
+    cache = integrations.memcached()
     resp = json.dumps({'message': 'how you doing'})
     cache.set('test', resp.encode('utf-8'))
-    return json.loads(cache.get('test').decode('utf-8'))
+    res = json.loads(cache.get('test').decode('utf-8'))
+    cache.close()
+    return res
 
 
 @app.get('/test_amqp')
 def test_amqp():
+    amqp, channel = integrations.amqp()
     channel.queue_declare(queue='hello')
+
     pub_body = secrets.token_urlsafe(16)
     channel.basic_publish(
         exchange='',
@@ -40,19 +47,25 @@ def test_amqp():
     )
     for method_frame, properties, body_bytes in channel.consume('hello', inactivity_timeout=1):
         if method_frame is None:
+            logger = integrations.logger()
             logger.print(Level.WARN, 'test_amqp reached inactivity timeout')
             logger.connection.commit()
             channel.cancel()
+            amqp.close()
+            logger.connection.close()
             return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
         channel.basic_ack(method_frame.delivery_tag)
         con_body = body_bytes.decode('utf-8')
         if con_body != pub_body:
+            logger = integrations.logger()
             logger.print(
                 Level.WARN,
                 'test_amqp expected response {} but got {}',
                 pub_body, con_body
             )
             logger.connection.commit()
+            logger.close()
         else:
             channel.cancel()
+            amqp.close()
             return Response(status_code=status.HTTP_200_OK)

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,6 @@ import secrets
 
 
 app = FastAPI()  # noqa
-logger = LOGGER.with_iden('main.py')  # noqa
 
 
 @app.get('/')


### PR DESCRIPTION
A more clever solution is likely going to be required, but this at least should get consistent behavior for now. If this works the next thing would be to switch to context managers so we can later decide whether or not to keep the connection alive. This addresses #2 