### PR TITLE
CORS allow all

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ ujson==1.35
 urllib3==1.25.8
 uvicorn==0.11.3
 websockets==8.1
+flask-cors==3.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,3 @@ ujson==1.35
 urllib3==1.25.8
 uvicorn==0.11.3
 websockets==8.1
-flask-cors==3.0.8

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    allow_orgins=['*'],
+    allow_origins=['*'],
     allow_credentials=False,
     allow_methods=['*'],
     allow_headers=['*']

--- a/src/main.py
+++ b/src/main.py
@@ -4,12 +4,14 @@ import integrations as itgs
 import json
 import secrets
 import users.router
+from flask_cors import CORS
 
 
 app = FastAPI(
     title='RedditLoans',
     description='See https://github.com/LoansBot'
 )
+CORS(app)
 app.include_router(users.router.router, prefix='/users')
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,17 +1,23 @@
 from fastapi import FastAPI, Response, status
+from fastapi.middleware.cors import CORSMiddleware
 from lblogging import Level
 import integrations as itgs
 import json
 import secrets
 import users.router
-from flask_cors import CORS
 
 
 app = FastAPI(
     title='RedditLoans',
     description='See https://github.com/LoansBot'
 )
-CORS(app)
+app.add_middleware(
+    CORSMiddleware,
+    allow_orgins=['*'],
+    allow_credentials=False,
+    allow_methods=['*'],
+    allow_headers=['*']
+)
 app.include_router(users.router.router, prefix='/users')
 
 


### PR DESCRIPTION
We are not relying on CORS as a defense mechanism. Using only
local storage on our front-end is both cleaner technically and
completely sidesteps the need for cors to stop browsers from doing
dangerous things.

Furthermore, we're totally ok with other websites relying on our API
right now. For the endpoints which are particularly security-sensitive,
we will use recaptcha explicitly which will perform domain
validation.