### PR TITLE
Switch from authtoken cookie to Authorization header

### DIFF
--- a/src/users/helper.py
+++ b/src/users/helper.py
@@ -64,6 +64,20 @@ def get_valid_passwd_auth(
     return id_
 
 
+def get_authtoken_from_header(authorization):
+    """Converts the string or None value that was passed in an authorization
+    header to the corresponding authtoken if possible, otherwise returns
+    None"""
+    if authorization is None:
+        return None
+    spl = authorization.split(' ', 2)
+    if len(spl) != 2:
+        return None
+    if spl[0] != 'bearer':
+        return None
+    return spl[1]
+
+
 def get_auth_info_from_token_auth(
         conn, cursor, auth: models.TokenAuthentication) -> typing.Optional[
             typing.Tuple[int, int]]:

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -84,14 +84,10 @@ def logout(auth: models.TokenAuthentication):
     }
 )
 def me(user_id: int, authorization: str = Header(None)):
-    if authorization is None:
+    authtoken = helper.get_authtoken_from_header(authorization)
+    if authtoken is None:
         return Response(status_code=403)
-    spl = authorization.split(' ', 2)
-    if len(spl) != 2:
-        return Response(status_code=403)
-    if spl[0] != 'bearer':
-        return Response(status_code=403)
-    authtoken = spl[1]
+
     with itgs.database() as conn:
         cursor = conn.cursor()
         info = helper.get_auth_info_from_token_auth(

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Cookie
+from fastapi import APIRouter, Header
 from fastapi.responses import Response, JSONResponse
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 from . import helper
@@ -83,9 +83,15 @@ def logout(auth: models.TokenAuthentication):
         403: {'description': 'Token authentication failed'}
     }
 )
-def me(user_id: int, authtoken: str = Cookie(None)):
-    if authtoken is None:
+def me(user_id: int, authorization: str = Header(None)):
+    if authorization is None:
         return Response(status_code=403)
+    spl = authorization.split(' ', 2)
+    if spl.length != 2:
+        return Response(status_code=403)
+    if spl[0] != 'bearer':
+        return Response(status_code=403)
+    authtoken = spl[1]
     with itgs.database() as conn:
         cursor = conn.cursor()
         info = helper.get_auth_info_from_token_auth(

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -87,7 +87,7 @@ def me(user_id: int, authorization: str = Header(None)):
     if authorization is None:
         return Response(status_code=403)
     spl = authorization.split(' ', 2)
-    if spl.length != 2:
+    if len(spl) != 2:
         return Response(status_code=403)
     if spl[0] != 'bearer':
         return Response(status_code=403)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -165,7 +165,7 @@ class AuthTests(unittest.TestCase):
 
             r = requests.get(
                 f'{HOST}/users/{user_id}/me',
-                cookies={'authtoken': 'testtoken'}
+                headers={'Authorization': 'bearer testtoken'}
             )
             r.raise_for_status()
             self.assertEqual(r.status_code, 200)
@@ -274,6 +274,31 @@ class AuthTests(unittest.TestCase):
                 }
             )
             self.assertEqual(r.status_code, 400)
+
+    def test_me_no_token(self):
+        r = requests.get(f'{HOST}/users/1/me')
+        self.assertEqual(r.status_code, 403)
+
+    def test_me_single_string_token(self):
+        r = requests.get(
+            f'{HOST}/users/1/me',
+            headers={'Authorization': 'token'}
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_me_bad_token(self):
+        r = requests.get(
+            f'{HOST}/users/1/me',
+            headers={'Authorization': 'bearer token'}
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_me_token_spaces(self):
+        r = requests.get(
+            f'{HOST}/users/1/me',
+            headers={'Authorization': 'bearer token token'}
+        )
+        self.assertEqual(r.status_code, 403)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This plays nicer with using fetch from non-primary domains, and generally is easier if we use the credentials omit strategy.