### PR TITLE
Add log routes, improve how integrations are passed around

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,6 @@ jobs:
         path: ./database
     - name: Setup database dependencies
       run: |
-        sudo apt update
         sudo apt install -yqq build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev postgresql-common libpq-dev postgresql-client
         python -m pip install -r ./database/requirements.txt
     - name: Initialize database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
         path: ./database
     - name: Setup database dependencies
       run: |
+        sudo apt update
         sudo apt install -yqq build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev postgresql-common libpq-dev postgresql-client
         python -m pip install -r ./database/requirements.txt
     - name: Initialize database

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -70,5 +70,6 @@ def amqp(val=None):
     try:
         yield amqp, channel
     finally:
+        print('AMQP closing from finally block')
         channel.close()
         amqp.close()

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -6,6 +6,7 @@ import psycopg2
 import pika
 import os
 from contextlib import contextmanager
+import logging
 
 
 @contextmanager
@@ -54,7 +55,7 @@ def amqp(val=None):
     if val is not None:
         yield val
         return
-
+    logging.getLogger("pika").setLevel(logging.WARNING)
     parameters = pika.ConnectionParameters(
         os.environ['AMQP_HOST'],
         int(os.environ['AMQP_PORT']),

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -70,6 +70,5 @@ def amqp(val=None):
     try:
         yield amqp, channel
     finally:
-        print('AMQP closing from finally block')
         channel.close()
         amqp.close()

--- a/src/lazy_integrations.py
+++ b/src/lazy_integrations.py
@@ -1,0 +1,118 @@
+"""This package provides a class-based version of integrations which has
+all of them, but they are lazily initialized. Acts as a context manager,
+and any connections which are actually used are cleaned up at the end
+of the context."""
+import integrations as itgs
+
+
+class LazyIntegrations:
+    """Contains all the integrations as lazy-loaded properties. If they are
+    requested they are initialized and cleaned up when this context manager
+    exits.
+
+    This will expose a read-only database connection as well as a write
+    database connection. Although not currently used, it should be
+    anticipated that these might be different connections. If this would
+    break things, set "no_read_only" to True to guarrantee the result of the
+    read connection is the same as the write connection.
+    """
+    def __init__(self, no_read_only=False):
+        self.closures = []
+        self.no_read_only = no_read_only
+        self._logger = None
+        self._conn = None
+        self._cursor = None
+        self._amqp = None
+        self._channel = None
+        self._cache = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        errors = []
+        for closure in self.closures:
+            try:
+                closure()
+            except Exception as e:  # noqa
+                # we need to delay these to give other closures
+                # an opportunity
+                errors.append(e)
+
+        if len(errors) == 1:
+            raise errors[0]
+        elif errors:
+            raise Exception(f'Many errors while shutting down integrations: {errors}')
+
+    @property
+    def logger(self):
+        """Fetch the logger instance, which will auto-commit"""
+        if self._logger is not None:
+            return self._logger
+
+        ctx = itgs.logger()
+        self._logger = ctx.__enter__()
+        self.closures.append(ctx.__exit__)
+        return self._logger
+
+    @property
+    def read_cursor(self):
+        """Fetches a database cursor that is only promised to support
+        reads. This may be the same connection as write_conn."""
+        return self.write_cursor
+
+    @property
+    def write_conn(self):
+        """Fetch the writable database connection"""
+        return self.write_conn_and_cursor[0]
+
+    @property
+    def write_cursor(self):
+        "Fetch the writable database cursor"
+        return self.write_conn_and_cursor[1]
+
+    @property
+    def write_conn_and_cursor(self):
+        """Returns the writable database connection alongside the cursor. The
+        connection can be used to commit."""
+        if self._conn is not None:
+            return (self._conn, self._cursor)
+
+        ctx = itgs.database()
+        self._conn = ctx.__enter__()
+        self.closures.append(ctx.__exit__)
+        self._cursor = self._conn.cursor()
+        return (self._conn, self._cursor)
+
+    @property
+    def amqp(self):
+        """Get the advanced message queue pika instance, which is really
+        only necessary if you need to declare custom channels"""
+        return self.amqp_and_channel[0]
+
+    @property
+    def channel(self):
+        """The AMQP channel to use."""
+        return self.amqp_and_channel[1]
+
+    @property
+    def amqp_and_channel(self):
+        """Get both the AMQP pika instance and the channel we are using"""
+        if self._amqp is not None:
+            return (self._amqp, self._channel)
+
+        ctx = itgs.amqp()
+        self._aqmp, self._channel = ctx.__enter__()
+        self.closures.append(ctx.__exit__)
+        return (self._aqmp, self._channel)
+
+    @property
+    def cache(self):
+        """Get the memcached client"""
+        if self._cache is not None:
+            return self._cache
+
+        ctx = itgs.memcached()
+        self._cache = ctx.__enter__()
+        self.closures.append(ctx.__exit__)
+        return self._cache

--- a/src/lazy_integrations.py
+++ b/src/lazy_integrations.py
@@ -44,6 +44,7 @@ class LazyIntegrations:
             raise errors[0]
         elif errors:
             raise Exception(f'Many errors while shutting down integrations: {errors}')
+        return False
 
     @property
     def logger(self):
@@ -100,14 +101,12 @@ class LazyIntegrations:
     def amqp_and_channel(self):
         """Get both the AMQP pika instance and the channel we are using"""
         if self._amqp is not None:
-            self.logger.print(Level.DEBUG, 'LazyIntegratinos returning existing amqp')
             return (self._amqp, self._channel)
 
-        self.logger.print(Level.DEBUG, 'LazyIntegrations initing amqp')
         ctx = itgs.amqp()
-        self._aqmp, self._channel = ctx.__enter__()
+        self._amqp, self._channel = ctx.__enter__()
         self.closures.append(ctx.__exit__)
-        return (self._aqmp, self._channel)
+        return (self._amqp, self._channel)
 
     @property
     def cache(self):

--- a/src/lazy_integrations.py
+++ b/src/lazy_integrations.py
@@ -3,7 +3,6 @@ all of them, but they are lazily initialized. Acts as a context manager,
 and any connections which are actually used are cleaned up at the end
 of the context."""
 import integrations as itgs
-from lblogging import Level
 
 
 class LazyIntegrations:

--- a/src/lazy_integrations.py
+++ b/src/lazy_integrations.py
@@ -3,6 +3,7 @@ all of them, but they are lazily initialized. Acts as a context manager,
 and any connections which are actually used are cleaned up at the end
 of the context."""
 import integrations as itgs
+from lblogging import Level
 
 
 class LazyIntegrations:
@@ -99,8 +100,10 @@ class LazyIntegrations:
     def amqp_and_channel(self):
         """Get both the AMQP pika instance and the channel we are using"""
         if self._amqp is not None:
+            self.logger.print(Level.DEBUG, 'LazyIntegratinos returning existing amqp')
             return (self._amqp, self._channel)
 
+        self.logger.print(Level.DEBUG, 'LazyIntegrations initing amqp')
         ctx = itgs.amqp()
         self._aqmp, self._channel = ctx.__enter__()
         self.closures.append(ctx.__exit__)

--- a/src/lazy_integrations.py
+++ b/src/lazy_integrations.py
@@ -29,11 +29,11 @@ class LazyIntegrations:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         errors = []
         for closure in self.closures:
             try:
-                closure()
+                closure(exc_type, exc_value, traceback)
             except Exception as e:  # noqa
                 # we need to delay these to give other closures
                 # an opportunity

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel
 
 class LogApplicationResponse(BaseModel):
     """Describes a single log application in a response"""
-    id: int
     name: str
 
 
@@ -13,7 +12,7 @@ class LogApplicationsResponse(SuccessResponse):
     """A response that indicates all of the log applications that we support
     logs for. This currently doesn't paginate as it's not expected to go
     above 10-20 results for the forseeable future."""
-    applications = list  # items are LogApplicationResponse
+    applications = dict  # keys are ids, items are LogApplicationResponse
 
 
 class LogResponse(BaseModel):

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -1,6 +1,7 @@
 """Contains the models that are used for logging"""
 from models import SuccessResponse
 from pydantic import BaseModel
+import typing
 
 
 class LogApplicationResponse(BaseModel):
@@ -12,7 +13,7 @@ class LogApplicationsResponse(SuccessResponse):
     """A response that indicates all of the log applications that we support
     logs for. This currently doesn't paginate as it's not expected to go
     above 10-20 results for the forseeable future."""
-    applications = dict  # keys are ids, items are LogApplicationResponse
+    applications = typing.Dict[int, LogApplicationResponse]
 
 
 class LogResponse(BaseModel):

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -1,7 +1,6 @@
 """Contains the models that are used for logging"""
 from models import SuccessResponse
 from pydantic import BaseModel
-import typing
 
 
 class LogApplicationResponse(BaseModel):
@@ -14,7 +13,7 @@ class LogApplicationsResponse(SuccessResponse):
     """A response that indicates all of the log applications that we support
     logs for. This currently doesn't paginate as it's not expected to go
     above 10-20 results for the forseeable future."""
-    applications = typing.List[LogApplicationResponse]
+    applications = list  # items are LogApplicationResponse
 
 
 class LogResponse(BaseModel):
@@ -37,4 +36,4 @@ class LogResponse(BaseModel):
 
 class LogsResponse(SuccessResponse):
     """The response that is sent when a list of logs are requested"""
-    logs: typing.List[LogResponse]
+    logs: list  # items are LogResponse

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -1,0 +1,40 @@
+"""Contains the models that are used for logging"""
+from models import SuccessResponse
+from pydantic import BaseModel
+import typing
+
+
+class LogApplicationResponse(BaseModel):
+    """Describes a single log application in a response"""
+    id: int
+    name: str
+
+
+class LogApplicationsResponse(SuccessResponse):
+    """A response that indicates all of the log applications that we support
+    logs for. This currently doesn't paginate as it's not expected to go
+    above 10-20 results for the forseeable future."""
+    applications = typing.List[LogApplicationResponse]
+
+
+class LogResponse(BaseModel):
+    """Describes the response for a single log event
+
+    @param app_id The id of the application which made this response
+    @param identifier Typically the name of the file which issued the
+      event
+    @param level The level of the event, from 0-4 where 0 = trace (see
+      https://github.com/LoansBot/logging/blob/master/src/lblogging/level.py)
+    @param message The message associated with the event
+    @param created_at When the message was issued in seconds since utc epoch
+    """
+    app_id: int
+    identifier: str
+    level: int
+    message: str
+    created_at: int
+
+
+class LogsResponse(SuccessResponse):
+    """The response that is sent when a list of logs are requested"""
+    logs: typing.List[LogResponse]

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -13,7 +13,7 @@ class LogApplicationsResponse(SuccessResponse):
     """A response that indicates all of the log applications that we support
     logs for. This currently doesn't paginate as it's not expected to go
     above 10-20 results for the forseeable future."""
-    applications = typing.Dict[int, LogApplicationResponse]
+    applications: typing.Dict[int, LogApplicationResponse]
 
 
 class LogResponse(BaseModel):

--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -12,7 +12,10 @@ class LogApplicationResponse(BaseModel):
 class LogApplicationsResponse(SuccessResponse):
     """A response that indicates all of the log applications that we support
     logs for. This currently doesn't paginate as it's not expected to go
-    above 10-20 results for the forseeable future."""
+    above 10-20 results for the forseeable future.
+
+    Note that json has only string keys, so clients need to reparse as ints.
+    """
     applications: typing.Dict[int, LogApplicationResponse]
 
 

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -1,0 +1,105 @@
+from fastapi import APIRouter, Header
+from fastapi.responses import Response, JSONResponse
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from . import models
+import users.helper
+import integrations as itgs
+from datetime import datetime
+
+
+router = APIRouter()
+
+
+@router.get(
+    '/',
+    tags=['logs'],
+    responses={
+        200: {'description': 'Success', 'model': models.LogsResponse},
+        400: {'description': 'Application ids is not ints comma separated'},
+        403: {'description': 'Token authentication failed'}
+    }
+)
+def root(
+        min_created_at: int = None,
+        min_level: int = None,
+        application_ids: str = None,
+        limit: int = 25,
+        authorization: str = Header(None)):
+    """The main endpoint for querying logs. Typically the front-end will need
+    to query /applications as well so they can prettily display the
+    applications.
+
+    The endpoint requires the "logs" permission.
+    """
+    authtoken = users.helper.get_authtoken_from_header(authorization)
+    if authtoken is None:
+        return Response(status_code=403)
+    if application_ids is not None:
+        app_ids = application_ids.split(',')
+        try:
+            app_ids = [int(i) for i in app_ids]
+        except ValueError:
+            return Response(status_code=400)
+        if len(app_ids) == 0:
+            application_ids = None
+            app_ids = None
+    with itgs.database() as conn:
+        cursor = conn.cursor()
+        info = users.helper.get_auth_info_from_token_auth(
+            conn, cursor, models.TokenAuthentication(token=authtoken)
+        )
+        if info is None:
+            return Response(status_code=403)
+        authid = info[0]
+        if not users.helper.check_permission_on_authtoken(conn, cursor, authid, 'logs'):
+            return Response(status_code=403)
+
+        log_events = Table('log_events')
+        log_applications = Table('log_applications')
+        log_identifiers = Table('log_identifiers')
+        query = (
+            Query.from_(log_events).select(
+                log_events.level,
+                log_events.application_id,
+                log_identifiers.identifier,
+                log_events.message,
+                log_events.created_at
+            ).join(log_identifiers).on(
+                log_identifiers.id == log_events.identifier_id
+            )
+        )
+        params = []
+        if min_created_at is not None:
+            query = query.where(log_events.created_at >= Parameter('%s'))
+            params.append(datetime.fromtimestamp(min_created_at))
+        if min_level is not None:
+            query = query.where(log_events.level >= Parameter('%s'))
+            params.append(min_level)
+        if application_ids is not None:
+            query = query.where(log_events.application_id.isin([Parameter('%s') for _ in app_ids]))
+            for app_id in app_ids:
+                params.append(app_id)
+        query = query.limit(Parameter('%s'))
+        if limit is None or limit > 100 or limit <= 0:
+            params.append(100)
+        else:
+            params.append(limit)
+
+        cursor.execute(query.get_sql(), params)
+        result = []
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            row_cat: datetime = row[4]
+            result.append(models.LogResponse(
+                level=row[0],
+                app_id=row[1],
+                identifier=row[2],
+                message=row[3],
+                created_at=int(row_cat.timestamp())
+            ))
+        return JSONResponse(
+            status_code=200,
+            content=models.LogsResponse(logs=result)
+        )

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -12,7 +12,7 @@ router = APIRouter()
 
 
 @router.get(
-    '/',
+    '/?',
     tags=['logs'],
     responses={
         200: {'description': 'Success', 'model': models.LogsResponse},
@@ -34,8 +34,6 @@ def root(
     """
     authtoken = users.helper.get_authtoken_from_header(authorization)
     if authtoken is None:
-        with itgs.logger() as lgr:
-            lgr.print(Level.DEBUG, 'Someone tried to use /logs with no auth ({})', authorization)
         return Response(status_code=403)
     if application_ids is not None:
         app_ids = application_ids.split(',')
@@ -52,13 +50,9 @@ def root(
             conn, cursor, users.models.TokenAuthentication(token=authtoken)
         )
         if info is None:
-            with itgs.logger() as lgr:
-                lgr.print(Level.DEBUG, 'Someone tried to use /logs with invalid auth')
             return Response(status_code=403)
         authid = info[0]
         if not users.helper.check_permission_on_authtoken(conn, cursor, authid, 'logs'):
-            with itgs.logger() as lgr:
-                lgr.print(Level.DEBUG, 'User hit {} but did not have logs perms', info[1])
             return Response(status_code=403)
 
         log_events = Table('log_events')

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -107,7 +107,7 @@ def root(
 @router.get(
     '/applications',
     tags=['logs'],
-    response={
+    responses={
         200: {'description': 'Success', 'model': models.LogApplicationsResponse},
         403: {'description': 'Token authentication failed'}
     }

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -55,7 +55,6 @@ def root(
             return Response(status_code=403)
 
         log_events = Table('log_events')
-        log_applications = Table('log_applications')
         log_identifiers = Table('log_identifiers')
         query = (
             Query.from_(log_events).select(

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -44,10 +44,10 @@ def root(
         if len(app_ids) == 0:
             application_ids = None
             app_ids = None
-    with itgs.database() as conn:
+    with itgs.database() as conn, itgs.memcached() as cache:
         cursor = conn.cursor()
         info = users.helper.get_auth_info_from_token_auth(
-            conn, cursor, users.models.TokenAuthentication(token=authtoken)
+            cache, conn, cursor, users.models.TokenAuthentication(token=authtoken)
         )
         if info is None:
             return Response(status_code=403)
@@ -119,10 +119,10 @@ def applications(authorization: str = Header(None)):
     authtoken = users.helper.get_authtoken_from_header(authorization)
     if authtoken is None:
         return Response(status_code=403)
-    with itgs.database() as conn:
+    with itgs.database() as conn, itgs.memcached() as cache:
         cursor = conn.cursor()
         info = users.helper.get_auth_info_from_token_auth(
-            conn, cursor, users.models.TokenAuthentication(token=authtoken)
+            cache, conn, cursor, users.models.TokenAuthentication(token=authtoken)
         )
         if info is None:
             return Response(status_code=403)

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -5,7 +5,6 @@ from . import models
 import users.helper
 from lazy_integrations import LazyIntegrations as LazyItgs
 from datetime import datetime
-from lblogging import Level
 
 
 router = APIRouter()

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -5,6 +5,7 @@ from . import models
 import users.helper
 import integrations as itgs
 from datetime import datetime
+from lblogging import Level
 
 
 router = APIRouter()

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -5,6 +5,7 @@ from . import models
 import users.helper
 import integrations as itgs
 from datetime import datetime
+from lblogging import Level
 
 
 router = APIRouter()
@@ -133,6 +134,8 @@ def applications(authorization: str = Header(None)):
         cursor.execute(
             Query.from_(apps).select(apps.id, apps.name).get_sql()
         )
+        with itgs.logger() as lgr:
+            lgr.print(Level.DEBUG, 'Executed query {}', cursor.query.decode('utf-8'))
         result = {}
 
         while True:
@@ -140,7 +143,11 @@ def applications(authorization: str = Header(None)):
             if row is None:
                 break
             result[row[0]] = models.LogApplicationResponse(name=row[1])
+            with itgs.logger() as lgr:
+                lgr.print(Level.DEBUG, 'Found row {}', row)
 
+        with itgs.logger() as lgr:
+            lgr.print(Level.DEBUG, 'Returning result={}', result)
         return JSONResponse(
             status_code=200,
             content=models.LogApplicationsResponse(applications=result).dict(),

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -107,5 +107,5 @@ def root(
             ))
         return JSONResponse(
             status_code=200,
-            content=models.LogsResponse(logs=result)
+            content=models.LogsResponse(logs=result).dict()
         )

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -132,8 +132,6 @@ def applications(authorization: str = Header(None)):
         itgs.read_cursor.execute(
             Query.from_(apps).select(apps.id, apps.name).get_sql()
         )
-        with itgs.logger() as lgr:
-            lgr.print(Level.DEBUG, 'Executed query {}', itgs.read_cursor.query.decode('utf-8'))
         result = {}
 
         while True:
@@ -141,11 +139,7 @@ def applications(authorization: str = Header(None)):
             if row is None:
                 break
             result[row[0]] = models.LogApplicationResponse(name=row[1])
-            with itgs.logger() as lgr:
-                lgr.print(Level.DEBUG, 'Found row {}', row)
 
-        with itgs.logger() as lgr:
-            lgr.print(Level.DEBUG, 'Returning result={}', result)
         return JSONResponse(
             status_code=200,
             content=models.LogApplicationsResponse(applications=result).dict(),

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -5,6 +5,7 @@ from . import models
 import users.helper
 import integrations as itgs
 from datetime import datetime
+from lblogging import Level
 
 
 router = APIRouter()
@@ -33,6 +34,8 @@ def root(
     """
     authtoken = users.helper.get_authtoken_from_header(authorization)
     if authtoken is None:
+        with itgs.logger() as lgr:
+            lgr.print(Level.DEBUG, 'Someone tried to use /logs with no auth ({})', authorization)
         return Response(status_code=403)
     if application_ids is not None:
         app_ids = application_ids.split(',')
@@ -49,9 +52,13 @@ def root(
             conn, cursor, users.models.TokenAuthentication(token=authtoken)
         )
         if info is None:
+            with itgs.logger() as lgr:
+                lgr.print(Level.DEBUG, 'Someone tried to use /logs with invalid auth')
             return Response(status_code=403)
         authid = info[0]
         if not users.helper.check_permission_on_authtoken(conn, cursor, authid, 'logs'):
+            with itgs.logger() as lgr:
+                lgr.print(Level.DEBUG, 'User hit {} but did not have logs perms', info[1])
             return Response(status_code=403)
 
         log_events = Table('log_events')

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -46,7 +46,7 @@ def root(
     with itgs.database() as conn:
         cursor = conn.cursor()
         info = users.helper.get_auth_info_from_token_auth(
-            conn, cursor, models.TokenAuthentication(token=authtoken)
+            conn, cursor, users.models.TokenAuthentication(token=authtoken)
         )
         if info is None:
             return Response(status_code=403)

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -143,7 +143,7 @@ def applications(authorization: str = Header(None)):
 
         return JSONResponse(
             status_code=200,
-            content=models.LogApplicationResponse(applications=result).dict(),
+            content=models.LogApplicationsResponse(applications=result).dict(),
             headers={
                 'Cache-Control': 'public, max-age=86400, stale-if-error=2419200'
             }

--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -5,7 +5,6 @@ from . import models
 import users.helper
 import integrations as itgs
 from datetime import datetime
-from lblogging import Level
 
 
 router = APIRouter()

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import integrations as itgs
 import json
 import secrets
 import users.router
+import logs.router
 
 
 app = FastAPI(
@@ -19,6 +20,7 @@ app.add_middleware(
     allow_headers=['*']
 )
 app.include_router(users.router.router, prefix='/users')
+app.include_router(logs.router.router, prefix='/logs')
 
 
 @app.get('/')

--- a/src/users/helper.py
+++ b/src/users/helper.py
@@ -294,10 +294,11 @@ def check_permission_on_authtoken(conn, cursor, authid, perm_name) -> bool:
     cursor.execute(
         Query.from_(authtoken_perms).select(1)
         .join(perms).on(authtoken_perms.permission_id == perms.id)
-        .where(authtoken_perms.id == authid)
-        .where(perms.name == perm_name)
+        .where(authtoken_perms.authtoken_id == Parameter('%s'))
+        .where(perms.name == Parameter('%s'))
         .limit(1)
-        .get_sql()
+        .get_sql(),
+        (authid, perm_name)
     )
     row = cursor.fetchone()
     return row is not None

--- a/src/users/helper.py
+++ b/src/users/helper.py
@@ -284,3 +284,20 @@ RETURNING id
     if commit:
         conn.commit()
     return passauth_id
+
+
+def check_permission_on_authtoken(conn, cursor, authid, perm_name) -> bool:
+    """Checks that the given authorization token has the given permission. If
+    the authorization token does not exist this returns False"""
+    perms = Table('permissions')
+    authtoken_perms = Table('authtoken_permissions')
+    cursor.execute(
+        Query.from_(authtoken_perms).select(1)
+        .join(perms).on(authtoken_perms.permission_id == perms.id)
+        .where(authtoken_perms.id == authid)
+        .where(perms.name == perm_name)
+        .limit(1)
+        .get_sql()
+    )
+    row = cursor.fetchone()
+    return row is not None

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -1,6 +1,7 @@
 """Contains the models that are used for users"""
 from models import SuccessResponse
 from pydantic import BaseModel
+import typing
 
 
 class PasswordAuthentication(BaseModel):
@@ -45,3 +46,8 @@ class UserShowSelfResponse(BaseModel):
     """The response that's provided if you GET yourself; where your identity
     is proven using a token"""
     username: str
+
+
+class UserPermissions(BaseModel):
+    """The response that's provided for a users permissions."""
+    permissions: typing.List[str]

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -6,7 +6,7 @@ from . import models
 import models as main_models
 import security
 import integrations as itgs
-from datetime import datetime, timedelta
+from datetime import timedelta
 import os
 import uuid
 import time

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -11,7 +11,6 @@ import os
 import uuid
 import time
 import json
-from lblogging import Level
 
 
 router = APIRouter()

--- a/src/users/router.py
+++ b/src/users/router.py
@@ -55,9 +55,9 @@ def login(auth: models.PasswordAuthentication):
     }
 )
 def logout(auth: models.TokenAuthentication):
-    with itgs.database() as conn:
+    with itgs.database() as conn, itgs.memcached() as cache:
         cursor = conn.cursor()
-        info = helper.get_auth_info_from_token_auth(conn, cursor, auth)
+        info = helper.get_auth_info_from_token_auth(cache, conn, cursor, auth)
         if info is None:
             return Response(status_code=403)
         auth_id = info[0]
@@ -91,10 +91,10 @@ def me(user_id: int, authorization: str = Header(None)):
     if authtoken is None:
         return Response(status_code=403)
 
-    with itgs.database() as conn:
+    with itgs.database() as conn, itgs.memcached() as cache:
         cursor = conn.cursor()
         info = helper.get_auth_info_from_token_auth(
-            conn, cursor, models.TokenAuthentication(token=authtoken),
+            cache, conn, cursor, models.TokenAuthentication(token=authtoken),
             require_user_id=user_id
         )
         if info is None:
@@ -143,10 +143,10 @@ def check_permissions(user_id: int, authorization: str = Header(None)):
     if authtoken is None:
         return Response(status_code=403)
 
-    with itgs.database() as conn:
+    with itgs.database() as conn, itgs.memcached() as cache:
         cursor = conn.cursor()
         info = helper.get_auth_info_from_token_auth(
-            conn, cursor, models.TokenAuthentication(token=authtoken),
+            cache, conn, cursor, models.TokenAuthentication(token=authtoken),
             require_user_id=user_id
         )
         if info is None:

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -78,7 +78,8 @@ def user_with_token(conn, cursor, add_perms=None, username='user_with_token', to
     finally:
         conn.rollback()
         cursor.execute(
-            Query.from_(users).delete().where(users.id == Parameter('%s')),
+            Query.from_(users).delete().where(users.id == Parameter('%s'))
+            .get_sql(),
             (user_id,)
         )
         for perm in perm_ids_to_delete:

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -1,5 +1,7 @@
 """Helper functions for testing"""
 from contextlib import contextmanager
+from pypika import PostgreSQLQuery as Query, Table, Parameter, Interval
+from pypika.functions import Now
 
 
 @contextmanager
@@ -11,4 +13,79 @@ def clear_tables(conn, cursor, tbls):
         conn.rollback()
         for tbl in tbls:
             cursor.execute(f'TRUNCATE {tbl} CASCADE')
+        conn.commit()
+
+
+@contextmanager
+def user_with_token(conn, cursor, add_perms=None, username='user_with_token', token='testtoken'):
+    """Creates a user with an authorization token, returning the id of the
+    user and the token to pass. This will delete the generated rows when
+    finished.
+    """
+    users = Table('users')
+    cursor.execute(
+        Query.into(users).columns(users.username)
+        .insert(Parameter('%s'))
+        .returning(users.id).get_sql(),
+        (username,)
+    )
+    (user_id,) = cursor.fetchone()
+    authtokens = Table('authtokens')
+    cursor.execute(
+        Query.into(authtokens).columns(
+            authtokens.user_id, authtokens.token, authtokens.expires_at
+        ).insert(Parameter('%s'), Parameter('%s'), Now() + Interval(hours=1))
+        .returning(authtokens.id)
+        .get_sql(),
+        (user_id, token)
+    )
+    (auth_id,) = cursor.fetchone()
+    perms = Table('permissions')
+    auth_perms = Table('authtoken_permissions')
+    perm_ids_to_delete = []
+    if add_perms:
+        for perm in add_perms:
+            cursor.execute(
+                Query.into(perms).columns(perms.name, perms.description)
+                .insert(Parameter('%s'), Parameter('%s'))
+                .on_conflict(perms.name).do_nothing()
+                .returning(perms.id)
+                .get_sql(),
+                (perm, 'Testing')
+            )
+            row = cursor.fetchone()
+            if row is not None:
+                perm_ids_to_delete.append(row[0])
+                cursor.execute(
+                    Query.from_(perms).select(perms.id)
+                    .where(perms.name == Parameter('%s'))
+                    .get_sql(),
+                    (perm,)
+                )
+                row = cursor.fetchone()
+        cursor.execute(
+            Query.into(auth_perms)
+            .columns(auth_perms.authtoken_id, auth_perms.permission_id)
+            .from_(perms).select(Parameter('%s'), perms.id)
+            .where(perms.name.isin([Parameter('%s') for _ in add_perms]))
+            .get_sql(),
+            [auth_id] + list(add_perms)
+        )
+
+    conn.commit()
+    try:
+        yield (user_id, token)
+    finally:
+        conn.rollback()
+        cursor.execute(
+            Query.from_(users).delete().where(users.id == Parameter('%s')),
+            (user_id,)
+        )
+        for perm in perm_ids_to_delete:
+            cursor.execute(
+                Query.from_(perms).delete()
+                .where(perms.id.isin([Parameter('%s') for _ in perm_ids_to_delete]))
+                .get_sql(),
+                perm_ids_to_delete
+            )
         conn.commit()

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -11,22 +11,22 @@ class BasicResponseTests(unittest.TestCase):
     def test_root_gives_200(self):
         r = requests.get(HOST)
         r.raise_for_status()
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
     def test_log_gives_200(self):
         r = requests.get(HOST + '/test_log')
         r.raise_for_status()
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
     def test_cache_gives_200(self):
         r = requests.get(HOST + '/test_cache')
         r.raise_for_status()
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
     def test_amqp_gives_200(self):
         r = requests.get(HOST + '/test_amqp')
         r.raise_for_status()
-        self.assertEquals(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -65,6 +65,29 @@ class BasicResponseTests(unittest.TestCase):
             )
             self.assertEqual(r.status_code, 403)
 
+    def test_applications(self):
+        r = requests.get(HOST + '/test_log')
+        r.raise_for_status()
+        self.assertEqual(r.status_code, 200)
+
+        with helper.user_with_token(self.conn, self.cursor, ['logs']) as (user_id, token):
+            r = requests.get(
+                HOST + '/logs',
+                headers={'Authorization': f'bearer {token}'}
+            )
+            r.raise_for_status()
+            self.assertEqual(r.status_code, 200)
+
+            body = r.json()
+            self.assertIsInstance(body, dict)
+            self.assertIsInstance(body.get('applications'), dict)
+            self.assertGreaterEqual(len(body), 1)
+
+            for k, v in body['applications'].items():
+                self.assertIsInstance(k, int)
+                self.assertIsInstance(v, dict)
+                self.assertIsInstance(v.get('name'), str)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -1,0 +1,70 @@
+"""Contains basic tests for the /log endpoints."""
+import unittest
+import requests
+import os
+import helper
+import psycopg2
+
+
+HOST = os.environ['TEST_WEB_HOST']
+
+
+class BasicResponseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.conn = psycopg2.connect('')
+        cls.cursor = cls.conn.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.conn.close()
+
+    def test_logs(self):
+        # Test log isn't the best name for an endpoint which does this but it
+        # avoids coupling this test with where logs are stored in the backend
+        r = requests.get(HOST + '/test_log')
+        r.raise_for_status()
+        self.assertEqual(r.status_code, 200)
+
+        with helper.user_with_token(self.conn, self.cursor, ['logs']) as (user_id, token):
+            r = requests.get(
+                HOST + '/logs',
+                headers={'Authorization': f'bearer {token}'}
+            )
+            r.raise_for_status()
+            self.assertEqual(r.status_code, 200)
+
+            body = r.json()
+            self.assertIsInstance(body, dict, f'body={body}')
+            self.assertIsInstance(body.get('logs'), list, f'body={body}')
+            for event in body['logs']:
+                self.assertIsInstance(event, dict, f'event={event}')
+                self.assertIsInstance(event.get('app_id'), int, f'event={event}')
+                self.assertIsInstance(event.get('identifier'), str, f'event={event}')
+                self.assertIsInstance(event.get('level'), int, f'event={event}')
+                self.assertIsInstance(event.get('message'), str, f'event={event}')
+                self.assertIsInstance(event.get('created_at'), int, f'created_at={event}')
+
+    def test_logs_no_auth(self):
+        r = requests.get(HOST + '/logs')
+        self.assertEqual(r.status_code, 403)
+
+    def test_logs_valid_auth_but_no_perm(self):
+        with helper.user_with_token(self.conn, self.cursor) as (user_id, token):
+            r = requests.get(
+                HOST + '/logs',
+                headers={'Authorization': f'bearer {token}'}
+            )
+            self.assertEqual(r.status_code, 403)
+
+    def test_logs_valid_auth_but_wrong_perm(self):
+        with helper.user_with_token(self.conn, self.cursor, ['wrong']) as (user_id, token):
+            r = requests.get(
+                HOST + '/logs',
+                headers={'Authorization': f'bearer {token}'}
+            )
+            self.assertEqual(r.status_code, 403)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -84,7 +84,11 @@ class BasicResponseTests(unittest.TestCase):
             self.assertGreaterEqual(len(body), 1)
 
             for k, v in body['applications'].items():
-                self.assertIsInstance(k, int)
+                self.assertIsInstance(k, str)
+                try:
+                    int(k)
+                except ValueError:
+                    self.assertFalse(True, f'key is not a str\'d int: {k} (body={body})')
                 self.assertIsInstance(v, dict)
                 self.assertIsInstance(v.get('name'), str)
 

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -80,7 +80,7 @@ class BasicResponseTests(unittest.TestCase):
 
             body = r.json()
             self.assertIsInstance(body, dict)
-            self.assertIsInstance(body.get('applications'), dict)
+            self.assertIsInstance(body.get('applications'), dict, f'body={body}')
             self.assertGreaterEqual(len(body), 1)
 
             for k, v in body['applications'].items():

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -72,7 +72,7 @@ class BasicResponseTests(unittest.TestCase):
 
         with helper.user_with_token(self.conn, self.cursor, ['logs']) as (user_id, token):
             r = requests.get(
-                HOST + '/logs',
+                HOST + '/logs/applications',
                 headers={'Authorization': f'bearer {token}'}
             )
             r.raise_for_status()


### PR DESCRIPTION
This adds logging-related endpoints, and uses a lazy loading technique to avoid function signatures being blown up while still not initializing excess connections.

This meant it was relatively seamless to support read-only DB connections in the future, which could be a scaling improvement. In doing this this adjusted `users.helper.get_auth_info_from_token_auth` to no longer touch the last seen at or delete auth tokens which seem to have been leaked. The last seen at doesn't currently have a replacement:

Here is how we could replace the last_seen_at functionality so that we don't need those web-workers using write connections - store the value in the cache and send the auth id to a queue. If a bknd job worker sees the auth id in the queue and the value is still in the cache and the auth token is still valid, update the last seen at to the value in the cache). If the worker gets behind then we don't get last_seen_at values, which should be fine