### PR TITLE
Support id-pagination on logs

### DIFF
--- a/src/logs/models.py
+++ b/src/logs/models.py
@@ -22,6 +22,7 @@ class LogApplicationsResponse(SuccessResponse):
 class LogResponse(BaseModel):
     """Describes the response for a single log event
 
+    @param id The id of the log event, which is a useful way to paginate
     @param app_id The id of the application which made this response
     @param identifier Typically the name of the file which issued the
       event
@@ -30,6 +31,7 @@ class LogResponse(BaseModel):
     @param message The message associated with the event
     @param created_at When the message was issued in seconds since utc epoch
     """
+    id: int
     app_id: int
     identifier: str
     level: int

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -39,6 +39,7 @@ class BasicResponseTests(unittest.TestCase):
             self.assertIsInstance(body.get('logs'), list, f'body={body}')
             for event in body['logs']:
                 self.assertIsInstance(event, dict, f'event={event}')
+                self.assertIsInstance(event.get('id'), int, f'event={event}')
                 self.assertIsInstance(event.get('app_id'), int, f'event={event}')
                 self.assertIsInstance(event.get('identifier'), str, f'event={event}')
                 self.assertIsInstance(event.get('level'), int, f'event={event}')


### PR DESCRIPTION
This is less prone to error since if we just keep incrementing ids on
the front-end we don't miss anything. Leaks how many logs we
have but we don't really care since we share all our metrics anyway