### PR TITLE
Ensure consistent log event ordering

### DIFF
--- a/src/logs/router.py
+++ b/src/logs/router.py
@@ -67,6 +67,7 @@ def root(
             ).join(log_identifiers).on(
                 log_identifiers.id == log_events.identifier_id
             )
+            .orderby(log_events.id)
         )
         params = []
         if min_created_at is not None:


### PR DESCRIPTION
Sorting by id ascending should be effectively equivalent to sorting by created at ascending, and where this breaks down it shouldn't cause issues. The front-end is going to use id pagination so it's preferably if the timestamps are slightly out of order compared to the ids