### PR TITLE
Bypass captcha on login with perm and ratelimit

### DIFF
--- a/src/security.py
+++ b/src/security.py
@@ -60,9 +60,9 @@ def ratelimit(itgs, environ_key, key_prefix, defaults=None) -> bool:
     maximum number of requests.
 
     example::
-        with itgs.memcached() as cache:
+        with LazyItgrs() as itgs
             ratelimit(
-                cache,
+                itgs,
                 'MAX_HUMAN_LOGINS',
                 'human_logins',  # will use human_logins_30 for 30 second store
                 {30: 5} # No more than 5 logins in 30 seconds

--- a/src/security.py
+++ b/src/security.py
@@ -61,12 +61,12 @@ def ratelimit(itgs, environ_key, key_prefix, defaults=None) -> bool:
 
     example::
         with LazyItgrs() as itgs
-            ratelimit(
-                itgs,
-                'MAX_HUMAN_LOGINS',
-                'human_logins',  # will use human_logins_30 for 30 second store
-                {30: 5} # No more than 5 logins in 30 seconds
-            )
+            if not ratelimit(
+                    itgs,
+                    'MAX_HUMAN_LOGINS',
+                    'human_logins',  # will use human_logins_30 for 30 second store
+                    {30: 5}): # No more than 5 logins in 30 seconds
+                return Response(status_code=429)
 
         # example to change to 5 in 30 seconds or 20 in 30 minutes using an
         # environment variable:

--- a/src/users/helper.py
+++ b/src/users/helper.py
@@ -61,9 +61,9 @@ def get_valid_passwd_auth(
                     'LOGIN_HUMAN_NO_CAPTCHA',
                     f'login_human_no_captcha_{user_id}',
                     {
-                        300: 2,
-                        600: 3,
-                        3600: 5
+                        int(timedelta(minutes=5).total_seconds()): 2,
+                        int(timedelta(minutes=10).total_seconds()): 3,
+                        int(timedelta(hours=1).total_seconds()): 3
                     }):
                 return None
             if not check_permission_on_passwd_auth(itgs, id_, 'bypass_captcha'):


### PR DESCRIPTION
This is because it's painful to make captchas work on localhost, and
we still want to be able to test logged-in endpoints locally even if
we can't test the captcha.