### PR TITLE
Move /claim captcha to /request_claim_token

### DIFF
--- a/src/users/models.py
+++ b/src/users/models.py
@@ -31,7 +31,7 @@ class TokenResponse(SuccessResponse):
 class ClaimRequestArgs(BaseModel):
     """A username and captcha token"""
     username: str
-    captcha_token: str = None
+    captcha_token: str
 
 
 class ClaimArgs(BaseModel):

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -28,9 +28,10 @@ class TokenResponse(SuccessResponse):
     expires_at_utc: float
 
 
-class Username(BaseModel):
-    """A username"""
+class ClaimRequestArgs(BaseModel):
+    """A username and captcha token"""
     username: str
+    captcha_token: str = None
 
 
 class ClaimArgs(BaseModel):
@@ -39,7 +40,6 @@ class ClaimArgs(BaseModel):
     user_id: int
     claim_token: str
     password: str
-    captcha_token: str
 
 
 class UserShowSelfResponse(BaseModel):


### PR DESCRIPTION
We mainly want a recaptcha on the requesting of the claim token to
prevent bots from spamming people with requests. There is no way
to get around this captcha.