### PR TITLE
Add cache-control to response queries

### DIFF
--- a/src/responses/router.py
+++ b/src/responses/router.py
@@ -31,7 +31,10 @@ def root(authorization: str = Header(None)):
         resps = itgs.read_cursor.fetchall()
         return JSONResponse(
             status_code=200,
-            content=models.ResponseIndex(responses=[r for (r,) in resps]).dict()
+            content=models.ResponseIndex(responses=[r for (r,) in resps]).dict(),
+            headers={
+                'Cache-Control': 'public, max-age=86400, stale-if-error=2629746'
+            }
         )
 
 
@@ -73,7 +76,10 @@ def show(name: str, authorization: str = Header(None)):
                 desc=row[3],
                 created_at=int(row[4].timestamp()),
                 updated_at=int(row[5].timestamp())
-            ).dict()
+            ).dict(),
+            headers={
+                'Cache-Control': 'public, max-age=86400, stale-if-error=2629746'
+            }
         )
 
 
@@ -168,7 +174,10 @@ def histories(name: str, limit: int = 10, authorization: str = Header(None)):
                     items=result
                 ),
                 number_truncated=number_truncated
-            ).dict()
+            ).dict(),
+            headers={
+                'Cache-Control': 'public, max-age=86400, stale-if-error=2629746'
+            }
         )
 
 


### PR DESCRIPTION
These are marked as public since it's not really a concern if these get leaked by crafty people - blocking reads is intended to reduce support requests rather than security. Marking them as public will not let anyone edit them without permission.

I chose 1-day since they do occasionally get updated, however usually only one moderator is editing the response at a time and the front-end can bust its own cache when it makes edits. A one-day lag time between passively syncing responses across moderators is unlikely to cause issues and the front-end can bust the cache if they click the edit button to make sure they don't start to edit something which has changed.

Also, you can always force refresh to see the latest stuff. I'd much rather do that the 1 in 1000 times I'm editing in return for disk-cache performance in the 999/1000 times I'm just checking what the response value is