### PR TITLE
Add test verifying no redirect on /endpoints/

### DIFF
--- a/src/authentication_methods/models.py
+++ b/src/authentication_methods/models.py
@@ -8,7 +8,7 @@ class AuthMethodPermissions(BaseModel):
 
 class AuthMethodHistoryItem(BaseModel):
     event_type: str
-    reason: str
+    reason: str = None
     username: str = None
     permission: str = None
     occurred_at: float

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ app = FastAPI(
     title='RedditLoans',
     description='See https://github.com/LoansBot'
 )
+app.router.redirect_slashes = False
 app.add_middleware(BlanketCORSMiddleware)
 app.include_router(users.router.router, prefix='/users')
 app.include_router(logs.router.router, prefix='/logs')

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -1371,6 +1371,9 @@ class EndpointsTests(unittest.TestCase):
                 )
             )
 
+    def test_no_open_redirect(self):
+        r = requests.get(HOST + '/endpoints/')
+        self.assertEqual(r.status_code, 404)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Open redirect vulnerability when redirecting slashes. Reported using the open bug bounty program; actually a vulnerability in starlette (trusts host headers by default). We do have trusted host header stored in X-Real-Host, but I can't figure out a good way to have starlette use it for redirects

```
Original Request

GET /api/endpoints/ HTTP/1.1
Host: redditloans.com
Connection: close
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36
DNT: 1
Accept: */*
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Referer: https://redditloans.com/endpoints.html
Accept-Encoding: gzip, deflate
Accept-Language: en-IN,en;q=0.9,en-GB;q=0.8,en-US;q=0.7,gu;q=0.6,hi;q=0.5

Original Response:

HTTP/1.1 307 Temporary Redirect
Server: nginx/1.18.0
Date: Tue, 01 Dec 2020 14:53:29 GMT
Location: https://redditloans.com/api/endpoints
Connection: close
X-Cache-Status: MISS
Content-Length: 0

Manipulated Request: 

GET /api/endpoints/ HTTP/1.1
Host: attacker.com
Connection: close
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36
DNT: 1
Accept: */*
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Referer: https://redditloans.com/endpoints.html
Accept-Encoding: gzip, deflate
Accept-Language: en-IN,en;q=0.9,en-GB;q=0.8,en-US;q=0.7,gu;q=0.6,hi;q=0.5

Response after manipulation: 

HTTP/1.1 307 Temporary Redirect
Server: nginx/1.18.0
Date: Tue, 01 Dec 2020 14:54:37 GMT
Location: https://attacker.com/api/endpoints
Connection: close
X-Cache-Status: MISS
Content-Length: 0
```